### PR TITLE
Shutdown gRPC channel after timeout exceeded

### DIFF
--- a/pythonlib/amlrealtimeai/client.py
+++ b/pythonlib/amlrealtimeai/client.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 import tensorflow.contrib
 import grpc
 import time
+from datetime import datetime, timedelta
 
 try:
     from tensorflow_serving.apis import predict_pb2
@@ -22,7 +23,7 @@ except ImportError:
 
 class PredictionClient:
 
-    def __init__(self, address: str, port: int, use_ssl:bool = False, access_token:str = ""):
+    def __init__(self, address: str, port: int, use_ssl:bool = False, access_token:str = "", channel_max_age:timedelta = timedelta(minutes=2)):
         if(address is None):
             raise ValueError("address")
 
@@ -33,12 +34,15 @@ class PredictionClient:
         metadata_transormer = (lambda x:[('authorization', access_token)])
         grpc.composite_channel_credentials(grpc.ssl_channel_credentials(),
                                            grpc.metadata_call_credentials(metadata_transormer))
-        if use_ssl:
-            self.channel = grpc.secure_channel(host, grpc.ssl_channel_credentials())
-        else:
-            self.channel = grpc.insecure_channel(host)
 
-        self.stub = prediction_service_pb2_grpc.PredictionServiceStub(self.channel)
+        if use_ssl:
+            self._channel_func = lambda: grpc.secure_channel(host, grpc.ssl_channel_credentials())
+        else:
+            self._channel_func = lambda: grpc.insecure_channel(host)
+
+        self.__channel_max_age = channel_max_age
+        self.__channel_usable_until = None
+
 
     def score_numpy_array(self, npdata):
         request = predict_pb2.PredictRequest()
@@ -72,17 +76,30 @@ class PredictionClient:
         request.inputs['images'].tensor_shape.dim.extend(self.make_dim_list(shape))
         return self.__predict(request, timeout)
 
+    def _get_datetime_now(self):
+        return datetime.now()
+
+    def _get_grpc_stub(self):
+        if(self.__channel_usable_until is None or self.__channel_usable_until < self._get_datetime_now()):
+            self.__stub = None
+            # Shutdown old channel
+            self.__channel = self._channel_func()
+            self.__channel_usable_until = self._get_datetime_now() + self.__channel_max_age
+            self.__stub = prediction_service_pb2_grpc.PredictionServiceStub(self.__channel)
+        return self.__stub
+
     def __predict(self, request, timeout):
         retry_count = 5
         sleep_delay = 1
 
         while(True):
             try:
-                result = self.stub.Predict(request, timeout)
+                result = self._get_grpc_stub().Predict(request, timeout)
                 return result.outputs["output_alias"]
-            except grpc.RpcError:
+            except grpc.RpcError as rpcError:
                 retry_count = retry_count - 1
                 if(retry_count <= 0):
                     raise
                 time.sleep(sleep_delay)
                 sleep_delay = sleep_delay * 2
+                print("Retrying", rpcError)

--- a/pythonlib/amlrealtimeai/client.py
+++ b/pythonlib/amlrealtimeai/client.py
@@ -23,7 +23,7 @@ except ImportError:
 
 class PredictionClient:
 
-    def __init__(self, address: str, port: int, use_ssl:bool = False, access_token:str = "", channel_max_age:timedelta = timedelta(minutes=2)):
+    def __init__(self, address: str, port: int, use_ssl:bool = False, access_token:str = "", channel_shutdown_timeout:timedelta = timedelta(minutes=2)):
         if(address is None):
             raise ValueError("address")
 
@@ -40,7 +40,7 @@ class PredictionClient:
         else:
             self._channel_func = lambda: grpc.insecure_channel(host)
 
-        self.__channel_max_age = channel_max_age
+        self.__channel_shutdown_timeout = channel_shutdown_timeout
         self.__channel_usable_until = None
 
 
@@ -84,8 +84,8 @@ class PredictionClient:
             self.__stub = None
             # Shutdown old channel
             self.__channel = self._channel_func()
-            self.__channel_usable_until = self._get_datetime_now() + self.__channel_max_age
             self.__stub = prediction_service_pb2_grpc.PredictionServiceStub(self.__channel)
+        self.__channel_usable_until = self._get_datetime_now() + self.__channel_shutdown_timeout
         return self.__stub
 
     def __predict(self, request, timeout):

--- a/pythonlib/tests/integration_tests/test_create_service.py
+++ b/pythonlib/tests/integration_tests/test_create_service.py
@@ -5,6 +5,7 @@ import os
 import uuid
 import tensorflow as tf
 import numpy as np
+import time
 
 from tests.integration_tests.test_utils import override_token_funcs, get_test_config, cleanup_old_test_services
 
@@ -59,6 +60,12 @@ def test_create_update_and_delete_service():
 
     second_model_id = deployment_client.register_model(model_name, service_def_path)
     deployment_client.update_service(service.id, second_model_id)
+
+    result = prediction_client.score_image("/tmp/share1/shark.jpg")
+    assert all([x == y for x, y in zip(np.array(result).shape, [1, 1, 2048])])
+
+    # wait for timeout of Azure LB
+    time.sleep(4 * 60 + 10)
 
     result = prediction_client.score_image("/tmp/share1/shark.jpg")
     assert all([x == y for x, y in zip(np.array(result).shape, [1, 1, 2048])])

--- a/pythonlib/tests/unit_tests/test_consumption_client.py
+++ b/pythonlib/tests/unit_tests/test_consumption_client.py
@@ -7,6 +7,7 @@ import grpc
 import tensorflow as tf
 import numpy as np
 from unittest import mock
+from datetime import datetime, timedelta
 
 try:
     from tensorflow.core.framework import tensor_shape_pb2
@@ -54,12 +55,12 @@ def test_score_image():
     image_file.close()
 
     client = PredictionClient("localhost", 50051)
-    client.stub = stub_mock
+    client._get_grpc_stub = lambda: stub_mock
 
     result = client.score_image(image_file_path)
     assert all([x == y for x, y in zip(result, [1, 2, 3])])
 
-    
+
 def test_score_numpy_array():
 
     def predict_mock(request, timeout):
@@ -77,7 +78,7 @@ def test_score_numpy_array():
     stub_mock.Predict = mock.MagicMock(side_effect=predict_mock)
 
     client = PredictionClient("localhost", 50051)
-    client.stub = stub_mock
+    client._get_grpc_stub = lambda: stub_mock
 
     result = client.score_numpy_array(np.asarray([[1, 2, 3], [4, 5, 6]], dtype='f'))
     assert all([x == y for x, y in zip(result[0], [ 11, 22, 33 ])])
@@ -106,7 +107,52 @@ def test_retrying_rpc_exception():
     stub_mock.Predict = mock.MagicMock(side_effect=predict_mock)
 
     client = PredictionClient("localhost", 50051)
-    client.stub = stub_mock
+    client._get_grpc_stub = lambda: stub_mock
 
     result = client.score_numpy_array(np.asarray([[1, 2]], dtype='f'))
     assert all([x == y for x, y in zip(result[0], [ 11, 22 ])])
+
+
+def test_create_new_channel_after_timeout_expires():
+
+    channel_mock_loaded = { 'value': 0 }
+
+    def unary_unary(id, request_serializer, response_deserializer):
+        result = mock.MagicMock()
+        if id == '/tensorflow.serving.PredictionService/Predict':
+            return_data = np.asarray([[ 1, 2, 3 ]])
+            return_tensor = tf.contrib.util.make_tensor_proto(return_data, types_pb2.DT_FLOAT, return_data.shape)
+            result.outputs = { "output_alias": return_tensor }
+        return lambda req, timeout: result
+
+    def load_channel_mock():
+        channel_mock_loaded['value'] += 1
+        return channel_mock
+
+    beginning = datetime.now()
+
+    channel_mock = mock.Mock()
+    channel_mock.unary_unary = mock.MagicMock(side_effect=unary_unary)
+
+    image_file_path = os.path.join(tempfile.mkdtemp(), "img.png")
+    image_file = open(image_file_path, "w")
+    image_file.write("abc")
+    image_file.close()
+
+    client = PredictionClient("localhost", 50051, channel_max_age=timedelta(minutes=1))
+    client._channel_func = load_channel_mock
+    
+    client._get_datetime_now = lambda: beginning
+    result = client.score_image(image_file_path)
+    assert all([x == y for x, y in zip(result, [1, 2, 3])])
+    assert channel_mock_loaded['value'] == 1
+
+    client._get_datetime_now = lambda: beginning.__add__(timedelta(seconds=50))
+    result = client.score_image(image_file_path)
+    assert all([x == y for x, y in zip(result, [1, 2, 3])])
+    assert channel_mock_loaded['value'] == 1
+
+    client._get_datetime_now = lambda: beginning.__add__(timedelta(seconds=70))
+    result = client.score_image(image_file_path)
+    assert all([x == y for x, y in zip(result, [1, 2, 3])])
+    assert channel_mock_loaded['value'] == 2


### PR DESCRIPTION
Close gRPC channel in case there are no requests for at least 2 minutes at the next predict call.