### PR TITLE
Lock azure.mgmt.storage dependency to address breaking change.

### DIFF
--- a/pythonlib/setup.py
+++ b/pythonlib/setup.py
@@ -51,7 +51,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     install_requires=[
-        'tensorflow==1.6.0', 'keras==2.1.5', 'requests==2.18.4', 'adal', 'azure-storage', 'azure.mgmt.storage'
+        'tensorflow==1.6.0', 'keras==2.1.5', 'requests==2.18.4', 'adal==1.0.2', 'azure-storage', 'azure.mgmt.storage==1.5.0'
     ],
     extras_require={
         # eg:


### PR DESCRIPTION
Azure.mgmt.storage recently released version 2.0.0 (6 days ago). This included breaking changes to their API. We'll lock the dependency to 1.5.0, until we can address the changes. (Fixes #28)